### PR TITLE
Fix SearchGuard roles

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -11,6 +11,7 @@ RUN \
   { \
     echo; \
     echo 'sg_role_monitoring:'; \
+    echo '  indices: {}'; \
     echo '  cluster:'; \
     echo '    - cluster:monitor/health'; \
     echo '    - cluster:monitor/nodes/info'; \


### PR DESCRIPTION
Apparently the Fabric8 OpenShift Elasticsearch plugin expects every searchguard
role definition to have an `indices` key (see [1]), which our
cluster-only role does not have.

[1]: https://github.com/fabric8io/openshift-elasticsearch-plugin/blob/8abaeedfd69d0be1bdbefa9078a6c9cec2f42a48/src/main/java/io/fabric8/elasticsearch/plugin/acl/SearchGuardRoles.java#L219